### PR TITLE
Prevent empty entries in Country/State/City dropdown

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -42,6 +42,10 @@ $users = get_users( array( 'role' => 'subscriber' ) );
                     $country = trim( $country );
 					$state   = get_user_meta( $user->ID, 'state', true );
 					$city    = get_user_meta( $user->ID, 'city', true );
+					
+					if ( empty( $country ) || 
+					   empty( $state ) ||
+						empty( $city ) ) continue;
 
 					// Long-form for the Dropdown, show only "USA" for each Host in the List for brevity
 					if ( strtolower( $country ) == 'usa' ) $country = 'United States of America';


### PR DESCRIPTION
Noticed this while checking #21 

Haven't actually looked at the database entries themselves, but I would assume this was caused by the fields not being required.

Whether they should be required or not is a different thing entirely, but selecting a blank entry messes up the form and forces you to refresh to be able to use it again in many cases.

This small commit just skips any entries with empty data.

It may need tweaks (Maybe blank Cities should be allowed, but not Countries or States? Not sure). Whatever the decision is it would be pretty easy to change.

![image](https://user-images.githubusercontent.com/7770631/32061331-5089d266-ba3f-11e7-96e6-8ae9eedf7c17.png)